### PR TITLE
调整test.py中图像预处理的过程

### DIFF
--- a/test.py
+++ b/test.py
@@ -35,8 +35,9 @@ def crnn_recognition(cropped_image, model):
     h, w = image.shape
     image = cv2.resize(image, (0,0), fx=w_now/w, fy=params.imgH/h, interpolation=cv2.INTER_CUBIC)
     image = (np.reshape(image, (params.imgH, w_now, 1))).transpose(2, 0, 1)
+    image = image.astype(np.float32) / 255.
     image = torch.from_numpy(image).type(torch.FloatTensor)
-    image.sub_(0.5).div_(0.5)
+    image.sub_(params.mean).div_(params.std)
     if torch.cuda.is_available():
         image = image.cuda()
     image = image.view(1, *image.size())


### PR DESCRIPTION
根据[dataset_v2.py](https://github.com/Sierkinhane/crnn_chinese_characters_rec/blob/master/dataset_v2.py)中的流程调整了test.py中的图像预处理过程。目前的代码已经计算了图像集的像素分布的均值与标准差，那么在检测时直接进行减0.5除0.5的操作就有些不合适了。
